### PR TITLE
Added ability to set plugins from bean

### DIFF
--- a/src/main/java/org/chartistjsf/component/chart/renderer/BarRenderer.java
+++ b/src/main/java/org/chartistjsf/component/chart/renderer/BarRenderer.java
@@ -113,6 +113,11 @@ public class BarRenderer extends BaseChartistRenderer {
 			writer.write(",chartPadding:" + model.getChartPadding());
 
 		writer.write(",reverseData:" + model.isReverseData());
+		
+		if (model.getPlugins() != null)
+		    writer.write(",plugins:" + model.getPlugins());
+		else if(chart.getPlugins() != null)
+		    writer.write(",plugins:" + chart.getPlugins());
 
 		writer.write("}");
 	}

--- a/src/main/java/org/chartistjsf/component/chart/renderer/LineRenderer.java
+++ b/src/main/java/org/chartistjsf/component/chart/renderer/LineRenderer.java
@@ -114,9 +114,11 @@ public class LineRenderer extends BaseChartistRenderer {
 		if (model.getChartPadding() != null)
 			writer.write(",chartPadding:" + model.getChartPadding());
 
-		if (chart.getPlugins() != null) {
-			writer.write(",plugins:" + chart.getPlugins());
-		}
+		if (model.getPlugins() != null)
+		    writer.write(",plugins:" + model.getPlugins());
+		else if(chart.getPlugins() != null)
+		    writer.write(",plugins:" + chart.getPlugins());
+		
 		writer.write(",fullWidth:" + model.isFullWidth());
 		writer.write(",reverseData:" + model.isReverseData());
 

--- a/src/main/java/org/chartistjsf/component/chart/renderer/PieRenderer.java
+++ b/src/main/java/org/chartistjsf/component/chart/renderer/PieRenderer.java
@@ -83,6 +83,11 @@ public class PieRenderer extends BaseChartistRenderer {
 			writer.write(",chartPadding:" + model.getChartPadding());
 
 		writer.write(",reverseData:" + model.isReverseData());
+		
+		if (model.getPlugins() != null)
+		    writer.write(",plugins:" + model.getPlugins());
+		else if(chart.getPlugins() != null)
+		    writer.write(",plugins:" + chart.getPlugins());
 
 		writer.write("}");
 	}

--- a/src/main/java/org/chartistjsf/model/chart/ChartModel.java
+++ b/src/main/java/org/chartistjsf/model/chart/ChartModel.java
@@ -44,6 +44,7 @@ public class ChartModel implements Serializable {
 	private String responsiveOptions;
 	private boolean animateAdvanced = false;
 	private boolean animatePath = false;
+	private String plugins;
 
 	public ChartModel() {
 		labels = new ArrayList<Object>();
@@ -61,6 +62,8 @@ public class ChartModel implements Serializable {
 		this.responsiveOptions = chartModel.responsiveOptions;
 		this.animateAdvanced = chartModel.animateAdvanced;
 		this.animatePath = chartModel.animatePath;
+		this.plugins = chartModel.plugins;
+		
 	}
 
 	/**
@@ -266,6 +269,27 @@ public class ChartModel implements Serializable {
 	 */
 	public void setAnimatePath(boolean animatePath) {
 		this.animatePath = animatePath;
+	}
+
+	/**
+	 * 
+	 * @return plugins
+	 */
+	public String getPlugins()
+	{
+	    return plugins;
+	}
+
+	/**
+	 * Specify one plugin or an array of plugins
+	 * Example one: [plugin1()]
+	 * Example two: [[plugin1()],[plugin2()]]
+	 * 
+	 * @param plugins the plugins to set
+	 */
+	public void setPlugins(String plugins)
+	{
+	    this.plugins = plugins;
 	}
 
 }


### PR DESCRIPTION
Hi, 
i modified your last version to add ability to set plugin also from bean with setPlugins(String plugins) method on every ChartModel class.

Example:
if i import inside a project [this plugin](https://github.com/CodeYellowBV/chartist-plugin-legend) and link it inside the chart page with 	_<h:outputScript library="js" name="chartist-plugin-legend.js" />_ then from java you can create a new PieChartModel and call _pieChartModelNoTarget.setPlugins("[Chartist.plugins.legend()]");_

If you dont' call setPlugins on a chartModel, the plugin works as you had already implemented.

Also, i extend the function for BarChart and PieChart models.

Let me know if you like it and if you want to integrate inside your project.

Thanks

